### PR TITLE
`computeWeights` takes FSRSItems. Added `computeWeightsAnki`

### DIFF
--- a/sandbox/src/App.tsx
+++ b/sandbox/src/App.tsx
@@ -1,6 +1,7 @@
 import { createResource, type Component } from 'solid-js'
 import init, { Fsrs } from 'fsrs-browser/fsrs_browser'
 import Train from './train.ts?worker'
+import { testSerialization } from './testSerialization'
 
 const App: Component = () => {
 	let [fsrs] = createResource(() => init().then(() => new Fsrs()))
@@ -43,6 +44,7 @@ const App: Component = () => {
 				Train with custom file
 				<input type='file' onChange={customFile} accept='.anki21' />
 			</label>
+			<button onclick={testSerialization}>Test Serialization</button>
 		</div>
 	)
 }

--- a/sandbox/src/testSerialization.ts
+++ b/sandbox/src/testSerialization.ts
@@ -1,0 +1,152 @@
+import { Fsrs } from 'fsrs-browser/fsrs_browser'
+
+export function testSerialization() {
+	const lengths = new Uint32Array(testItems.map((item) => item.reviews.length))
+	const ratings = new Uint32Array(
+		testItems.flatMap((item) => item.reviews.map((r) => r.rating)),
+	)
+	const deltaTs = new Uint32Array(
+		testItems.flatMap((item) => item.reviews.map((r) => r.delta_t)),
+	)
+	Fsrs.testSerialization(ratings, deltaTs, lengths)
+}
+
+interface FSRSReview {
+	rating: number
+	delta_t: number
+}
+
+interface FSRSItem {
+	reviews: FSRSReview[]
+}
+
+const testItems: FSRSItem[] = [
+	{
+		reviews: [
+			{
+				rating: 4,
+				delta_t: 0,
+			},
+			{
+				rating: 3,
+				delta_t: 5,
+			},
+		],
+	},
+	{
+		reviews: [
+			{
+				rating: 4,
+				delta_t: 0,
+			},
+			{
+				rating: 3,
+				delta_t: 5,
+			},
+			{
+				rating: 3,
+				delta_t: 11,
+			},
+		],
+	},
+	{
+		reviews: [
+			{
+				rating: 4,
+				delta_t: 0,
+			},
+			{
+				rating: 3,
+				delta_t: 2,
+			},
+		],
+	},
+	{
+		reviews: [
+			{
+				rating: 4,
+				delta_t: 0,
+			},
+			{
+				rating: 3,
+				delta_t: 2,
+			},
+			{
+				rating: 3,
+				delta_t: 6,
+			},
+		],
+	},
+	{
+		reviews: [
+			{
+				rating: 4,
+				delta_t: 0,
+			},
+			{
+				rating: 3,
+				delta_t: 2,
+			},
+			{
+				rating: 3,
+				delta_t: 6,
+			},
+			{
+				rating: 3,
+				delta_t: 16,
+			},
+		],
+	},
+	{
+		reviews: [
+			{
+				rating: 4,
+				delta_t: 0,
+			},
+			{
+				rating: 3,
+				delta_t: 2,
+			},
+			{
+				rating: 3,
+				delta_t: 6,
+			},
+			{
+				rating: 3,
+				delta_t: 16,
+			},
+			{
+				rating: 3,
+				delta_t: 39,
+			},
+		],
+	},
+	{
+		reviews: [
+			{
+				rating: 1,
+				delta_t: 0,
+			},
+			{
+				rating: 1,
+				delta_t: 1,
+			},
+		],
+	},
+	{
+		reviews: [
+			{
+				rating: 1,
+				delta_t: 0,
+			},
+			{
+				rating: 1,
+				delta_t: 1,
+			},
+			{
+				rating: 3,
+				delta_t: 1,
+			},
+		],
+	},
+]

--- a/sandbox/src/train.ts
+++ b/sandbox/src/train.ts
@@ -67,7 +67,7 @@ async function loadSqliteAndRun(ab: ArrayBuffer) {
 			i++
 		}
 		trainQuery.free()
-		let weights = fsrs.computeWeights(
+		let weights = fsrs.computeWeightsAnki(
 			cids,
 			eases,
 			factors,


### PR DESCRIPTION
Closes https://github.com/AlexErrant/fsrs-browser/issues/4

@L-M-Sherlock what do you think of this `computeWeights` API? In your issue/commit you pass FSRSItems as a string which you deserialize. Instead, my `computeWeights` takes 3 `[u32]`s, which I believe is a performance enhancement since it minimizes (de)serialization costs. I believe we should try to optimize perf here since the number of FSRSItems may get very large.