### PR TITLE
Fix/use default weights when weights is none

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,8 @@
 use burn::backend::NdArray;
-use fsrs::{anki_to_fsrs, to_revlog_entry, FSRSItem, FSRSReview, MemoryState, NextStates, FSRS};
+use fsrs::{
+    anki_to_fsrs, to_revlog_entry, FSRSItem, FSRSReview, MemoryState, NextStates, DEFAULT_WEIGHTS,
+    FSRS,
+};
 use log::info;
 use wasm_bindgen::prelude::*;
 
@@ -18,8 +21,14 @@ impl Default for FSRSwasm {
 impl FSRSwasm {
     #[cfg_attr(target_family = "wasm", wasm_bindgen(constructor))]
     pub fn new(weights: Option<Vec<f32>>) -> Self {
-        Self {
-            model: FSRS::new(weights.as_deref()).unwrap(),
+        if let Some(weights) = weights {
+            Self {
+                model: FSRS::new(Some(&weights)).unwrap(),
+            }
+        } else {
+            Self {
+                model: FSRS::new(Some(&DEFAULT_WEIGHTS)).unwrap(),
+            }
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,15 +21,12 @@ impl Default for FSRSwasm {
 impl FSRSwasm {
     #[cfg_attr(target_family = "wasm", wasm_bindgen(constructor))]
     pub fn new(weights: Option<Vec<f32>>) -> Self {
-        if let Some(weights) = weights {
-            Self {
-                model: FSRS::new(Some(&weights)).unwrap(),
-            }
-        } else {
-            Self {
-                model: FSRS::new(Some(&DEFAULT_WEIGHTS)).unwrap(),
-            }
+        let model = match weights {
+            Some(weights) => FSRS::new(Some(&weights)),
+            None => FSRS::new(Some(&DEFAULT_WEIGHTS)),
         }
+        .unwrap();
+        Self { model }
     }
 
     #[wasm_bindgen(js_name = computeWeightsAnki)]


### PR DESCRIPTION
Fix following error:

```
panicked at 'command requires weights to be set on creation', /Users/jarrettye/Codes/open-spaced-repetition/fsrs-browser/fsrs-rs/src/model.rs:232:14

Stack:

Error
    at imports.wbg.__wbg_new_abda76e883ba8a5f (http://[::]:8000/pkg/fsrs_browser.js:647:21)
    at http://[::]:8000/pkg/fsrs_browser_bg.wasm:wasm-function[909]:0xf2041
    at http://[::]:8000/pkg/fsrs_browser_bg.wasm:wasm-function[487]:0xdf6bf
    at http://[::]:8000/pkg/fsrs_browser_bg.wasm:wasm-function[763]:0xeff73
    at http://[::]:8000/pkg/fsrs_browser_bg.wasm:wasm-function[687]:0xed93c
    at http://[::]:8000/pkg/fsrs_browser_bg.wasm:wasm-function[210]:0xb2e44
    at http://[::]:8000/pkg/fsrs_browser_bg.wasm:wasm-function[296]:0xc8da6
    at Fsrs.memoryState (http://[::]:8000/pkg/fsrs_browser.js:306:18)
    at HTMLButtonElement.<anonymous> (http://[::]:8000/:27:31)
```