### PR TITLE
Fix/Content type not return `application/wasm`

### DIFF
--- a/sandbox/vite.config.ts
+++ b/sandbox/vite.config.ts
@@ -28,6 +28,11 @@ export default defineConfig(() => {
 			target: 'esnext',
 		},
 		optimizeDeps: {
+			// If you use Vite and install `fsrs-browser` from npm, you'll need the below `exclude` for reasons given here https://github.com/vitejs/vite/issues/8427
+			// since `fsrs-browser` uses wasm-pack. Without it, you'll run into the below error messages:
+			//     `WebAssembly.instantiateStreaming` failed because your server does not serve wasm with `application/wasm` MIME type. Falling back to `WebAssembly.instantiate` which is slower. Original error:
+			//     TypeError: Failed to execute 'compile' on 'WebAssembly': Incorrect response MIME type. Expected 'application/wasm'.
+			//     CompileError: WebAssembly.instantiate(): expected magic word 00 61 73 6d, found 3c 21 64 6f @+0
 			exclude: ['fsrs-browser'],
 		},
 	}

--- a/sandbox/vite.config.ts
+++ b/sandbox/vite.config.ts
@@ -27,5 +27,8 @@ export default defineConfig(() => {
 		build: {
 			target: 'esnext',
 		},
+		optimizeDeps: {
+			exclude: ['fsrs-browser'],
+		},
 	}
 })


### PR DESCRIPTION
I tried using `npm install fsrs-browser@0.6.0` but it doesn't work properly because when accessing `http://localhost:3000/node_modules/.vite/deps/fsrs_browser_bg.wasm`, it returns `text/html` instead. 

<img width="1455" alt="image" src="https://github.com/open-spaced-repetition/fsrs-browser/assets/62931549/dc4cfa92-8278-4a26-955a-a679f6dd58ac">
<img width="902" alt="content-type-html" src="https://github.com/open-spaced-repetition/fsrs-browser/assets/62931549/ecac514e-7f21-4ebc-9930-2cb4600d838b">



I found that this approach can resolve the issue:
- https://github.com/ishiko732/fsrs-browser/blob/e4ae8fba7adf930ffb405d360510a3341b91a8af/sandbox/vite.config.ts#L30-L32
- Ref: https://github.com/vitejs/vite/issues/10761

<img width="816" alt="npm-wasm" src="https://github.com/open-spaced-repetition/fsrs-browser/assets/62931549/1c320d3b-46de-4302-a2ab-bd11ee7ba12d">


