### PR TITLE
added progress bar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,6 +157,7 @@ checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 [[package]]
 name = "burn"
 version = "0.12.1"
+source = "git+https://github.com/open-spaced-repetition/burn.git?rev=404858e4db95c8f6ecd1d50d274aaf223c7bc1a7#404858e4db95c8f6ecd1d50d274aaf223c7bc1a7"
 dependencies = [
  "burn-core",
  "burn-train",
@@ -165,6 +166,7 @@ dependencies = [
 [[package]]
 name = "burn-autodiff"
 version = "0.12.1"
+source = "git+https://github.com/open-spaced-repetition/burn.git?rev=404858e4db95c8f6ecd1d50d274aaf223c7bc1a7#404858e4db95c8f6ecd1d50d274aaf223c7bc1a7"
 dependencies = [
  "burn-common",
  "burn-tensor",
@@ -175,6 +177,7 @@ dependencies = [
 [[package]]
 name = "burn-candle"
 version = "0.12.1"
+source = "git+https://github.com/open-spaced-repetition/burn.git?rev=404858e4db95c8f6ecd1d50d274aaf223c7bc1a7#404858e4db95c8f6ecd1d50d274aaf223c7bc1a7"
 dependencies = [
  "burn-tensor",
  "candle-core",
@@ -185,6 +188,7 @@ dependencies = [
 [[package]]
 name = "burn-common"
 version = "0.12.1"
+source = "git+https://github.com/open-spaced-repetition/burn.git?rev=404858e4db95c8f6ecd1d50d274aaf223c7bc1a7#404858e4db95c8f6ecd1d50d274aaf223c7bc1a7"
 dependencies = [
  "async-trait",
  "derive-new",
@@ -199,6 +203,7 @@ dependencies = [
 [[package]]
 name = "burn-compute"
 version = "0.12.1"
+source = "git+https://github.com/open-spaced-repetition/burn.git?rev=404858e4db95c8f6ecd1d50d274aaf223c7bc1a7#404858e4db95c8f6ecd1d50d274aaf223c7bc1a7"
 dependencies = [
  "burn-common",
  "derive-new",
@@ -215,6 +220,7 @@ dependencies = [
 [[package]]
 name = "burn-core"
 version = "0.12.1"
+source = "git+https://github.com/open-spaced-repetition/burn.git?rev=404858e4db95c8f6ecd1d50d274aaf223c7bc1a7#404858e4db95c8f6ecd1d50d274aaf223c7bc1a7"
 dependencies = [
  "bincode",
  "burn-autodiff",
@@ -242,6 +248,7 @@ dependencies = [
 [[package]]
 name = "burn-dataset"
 version = "0.12.1"
+source = "git+https://github.com/open-spaced-repetition/burn.git?rev=404858e4db95c8f6ecd1d50d274aaf223c7bc1a7#404858e4db95c8f6ecd1d50d274aaf223c7bc1a7"
 dependencies = [
  "csv",
  "derive-new",
@@ -260,6 +267,7 @@ dependencies = [
 [[package]]
 name = "burn-derive"
 version = "0.12.1"
+source = "git+https://github.com/open-spaced-repetition/burn.git?rev=404858e4db95c8f6ecd1d50d274aaf223c7bc1a7#404858e4db95c8f6ecd1d50d274aaf223c7bc1a7"
 dependencies = [
  "derive-new",
  "proc-macro2",
@@ -270,6 +278,7 @@ dependencies = [
 [[package]]
 name = "burn-fusion"
 version = "0.12.1"
+source = "git+https://github.com/open-spaced-repetition/burn.git?rev=404858e4db95c8f6ecd1d50d274aaf223c7bc1a7#404858e4db95c8f6ecd1d50d274aaf223c7bc1a7"
 dependencies = [
  "burn-common",
  "burn-tensor",
@@ -283,6 +292,7 @@ dependencies = [
 [[package]]
 name = "burn-ndarray"
 version = "0.12.1"
+source = "git+https://github.com/open-spaced-repetition/burn.git?rev=404858e4db95c8f6ecd1d50d274aaf223c7bc1a7#404858e4db95c8f6ecd1d50d274aaf223c7bc1a7"
 dependencies = [
  "burn-autodiff",
  "burn-common",
@@ -300,6 +310,7 @@ dependencies = [
 [[package]]
 name = "burn-tensor"
 version = "0.12.1"
+source = "git+https://github.com/open-spaced-repetition/burn.git?rev=404858e4db95c8f6ecd1d50d274aaf223c7bc1a7#404858e4db95c8f6ecd1d50d274aaf223c7bc1a7"
 dependencies = [
  "burn-common",
  "derive-new",
@@ -315,6 +326,7 @@ dependencies = [
 [[package]]
 name = "burn-train"
 version = "0.12.1"
+source = "git+https://github.com/open-spaced-repetition/burn.git?rev=404858e4db95c8f6ecd1d50d274aaf223c7bc1a7#404858e4db95c8f6ecd1d50d274aaf223c7bc1a7"
 dependencies = [
  "burn-core",
  "derive-new",
@@ -333,6 +345,7 @@ dependencies = [
 [[package]]
 name = "burn-wgpu"
 version = "0.12.1"
+source = "git+https://github.com/open-spaced-repetition/burn.git?rev=404858e4db95c8f6ecd1d50d274aaf223c7bc1a7#404858e4db95c8f6ecd1d50d274aaf223c7bc1a7"
 dependencies = [
  "burn-common",
  "burn-compute",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,9 @@ path = "./fsrs-rs"
 
 [dependencies.burn]
 # version = "0.10.0"
-# git = "https://github.com/burn-rs/burn.git"
-# rev = "d06cc2f239c53e7f88dad7e0b2bbe6757a17d66c"
-path = "./burn/burn"
+git = "https://github.com/open-spaced-repetition/burn.git"
+rev = "404858e4db95c8f6ecd1d50d274aaf223c7bc1a7"
+# path = "./burn/burn"
 default-features = false
 features = ["std", "train", "autodiff", "wasm-sync", "browser", "ndarray"]
 

--- a/sandbox/src/App.tsx
+++ b/sandbox/src/App.tsx
@@ -1,7 +1,15 @@
-import { createResource, type Component } from 'solid-js'
+import {
+	Accessor,
+	Setter,
+	VoidComponent,
+	createResource,
+	createSignal,
+	type Component,
+} from 'solid-js'
 import init, { Fsrs, initThreadPool } from 'fsrs-browser/fsrs_browser'
 import Train from './train.ts?worker'
 import { testSerialization } from './testSerialization'
+import { ProgressMessage } from './train'
 
 const App: Component = () => {
 	let [fsrs] = createResource(async () => {
@@ -9,6 +17,8 @@ const App: Component = () => {
 		await initThreadPool(navigator.hardwareConcurrency)
 		return new Fsrs()
 	})
+	let [itemsProcessed, setItemsProcessed] = createSignal(0)
+	let [itemsTotal, setItemsTotal] = createSignal(0)
 	return (
 		<div style={{ display: 'flex', 'flex-direction': 'column' }}>
 			<h1>FSRS Browser Example</h1>
@@ -41,15 +51,32 @@ const App: Component = () => {
 				onclick={async () => {
 					let db = await fetch('/collection.anki21')
 					let data = await db.arrayBuffer()
-					new Train().postMessage(data, [data])
+					trainOn(data, setItemsProcessed, setItemsTotal, itemsTotal)
 				}}
 			>
 				Train with example file
 			</button>
 			<label>
 				Train with custom file
-				<input type='file' onChange={customFile} accept='.anki21, .csv' />
+				<input
+					type='file'
+					onChange={(event) => {
+						const file =
+							// My mental static analysis says to use `currentTarget`, but it seems to randomly be null, hence `target`. I'm confused but whatever.
+							event.target.files?.item(0) ??
+							throwExp('There should be a file selected')
+						trainOn(file, setItemsProcessed, setItemsTotal, itemsTotal)
+					}}
+					accept='.anki21, .csv'
+				/>
 			</label>
+			<label for='train'>Train progress:</label>
+			<progress
+				id='train'
+				max={itemsTotal()}
+				value={itemsProcessed()}
+			></progress>
+			{itemsProcessed()}/{itemsTotal()}
 			<button onclick={testSerialization}>
 				<div>Test Serialization</div>
 				<div>(fails if fsrs-browser was built in release mode)</div>
@@ -58,20 +85,39 @@ const App: Component = () => {
 	)
 }
 
-async function customFile(
-	event: Event & {
-		currentTarget: HTMLInputElement
-		target: HTMLInputElement
-	},
+async function trainOn(
+	file_buffer: File | ArrayBuffer,
+	setItemsProcessed: Setter<number>,
+	setItemsTotal: Setter<number>,
+	itemsTotal: Accessor<number>,
 ): Promise<void> {
-	const file =
-		// My mental static analysis says to use `currentTarget`, but it seems to randomly be null, hence `target`. I'm confused but whatever.
-		event.target.files?.item(0) ?? throwExp('There should be a file selected')
-	if (file.name.endsWith('.csv')) {
-		new Train().postMessage(file)
+	let t = new Train()
+	let intervalId = 0
+	t.addEventListener('message', (m) => {
+		let msg = m.data as ProgressMessage
+		if (msg.tag === 'Start') {
+			intervalId = window.setInterval(() => {
+				// The progress vec is length 2. Grep 2291AF52-BEE4-4D54-BAD0-6492DFE368D8
+				const progress = new Uint32Array(msg.buffer, msg.pointer, 2)
+				setItemsProcessed(progress[0])
+				setItemsTotal(progress[1])
+			}, 100)
+		} else if (msg.tag === 'Stop') {
+			clearInterval(intervalId)
+			// It is not guaranteed that the final `itemsProcessed` message is equal to `itemsTotal`
+			// so we set it to the max upon `Stop` to make the bar full.
+			setItemsProcessed(itemsTotal())
+		}
+	})
+	if (file_buffer instanceof File) {
+		if (file_buffer.name.endsWith('.csv')) {
+			t.postMessage(file_buffer)
+		} else {
+			let ab = await file_buffer.arrayBuffer()
+			t.postMessage(ab, [ab])
+		}
 	} else {
-		let ab = await file.arrayBuffer()
-		new Train().postMessage(ab, [ab])
+		t.postMessage(file_buffer, [file_buffer])
 	}
 }
 

--- a/sandbox/src/App.tsx
+++ b/sandbox/src/App.tsx
@@ -1,7 +1,6 @@
 import {
 	Accessor,
 	Setter,
-	VoidComponent,
 	createResource,
 	createSignal,
 	type Component,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ impl FSRSwasm {
         eases: &[u8],
         ids: &[i64],
         types: &[u8],
-        progress: Progress,
+        progress: Option<Progress>,
     ) -> Vec<f32> {
         let revlog_entries = to_revlog_entry(cids, eases, ids, types);
         let items = anki_to_fsrs(revlog_entries);
@@ -49,21 +49,22 @@ impl FSRSwasm {
         ratings: &[u32],
         delta_ts: &[u32],
         lengths: &[u32],
-        progress: Progress,
+        progress: Option<Progress>,
     ) -> Vec<f32> {
         let items = Self::to_fsrs_items(ratings, delta_ts, lengths);
         self.train_and_set_parameters(items, progress)
     }
 
-    fn train_and_set_parameters(&mut self, items: Vec<FSRSItem>, progress: Progress) -> Vec<f32> {
+    fn train_and_set_parameters(
+        &mut self,
+        items: Vec<FSRSItem>,
+        progress: Option<Progress>,
+    ) -> Vec<f32> {
         #[cfg(debug_assertions)]
         warn!("You're training with a debug build... this is going to take a *long* time.");
         let parameters = self
             .model
-            .compute_parameters(
-                items,
-                Some(CombinedProgressState::new_shared(Some(progress))),
-            )
+            .compute_parameters(items, Some(CombinedProgressState::new_shared(progress)))
             .unwrap();
         self.model = FSRS::new(Some(&parameters)).unwrap();
         parameters


### PR DESCRIPTION
Closes https://github.com/open-spaced-repetition/fsrs-browser/issues/15

I eventually went with a solution that involved polling and reading from shared memory. Here's a high level overview:

* We create a `Progress.new()` struct in the web-worker and pass that to `computeParameters`.
* We use the `pointer()` method to get the memory address of `Progress` for Javascript's usage.
* Rust writes `itemsProcessed` and `itemsTotal` to the memory address of `Progress`.
* The Javascript main (UI) thread polls that memory address for updates.

The Javascript API for the Progress functionality is... not good, since the memory has to be instantiated in the worker thread, passed to Rust, and also passed to the main JS thread. I'm open to ideas on how to make it better!