### PR TITLE
update FSRS-rs to 1.3.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -726,7 +726,7 @@ checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "fsrs"
-version = "1.1.4"
+version = "1.3.3"
 dependencies = [
  "burn",
  "chrono",
@@ -735,6 +735,7 @@ dependencies = [
  "log",
  "ndarray",
  "ndarray-rand",
+ "priority-queue",
  "rand",
  "rayon",
  "serde",
@@ -1525,6 +1526,17 @@ name = "presser"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
+
+[[package]]
+name = "priority-queue"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714c75db297bc88a63783ffc6ab9f830698a6705aa0201416931759ef4c8183d"
+dependencies = [
+ "autocfg",
+ "equivalent",
+ "indexmap",
+]
 
 [[package]]
 name = "proc-macro2"

--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
           const stability = 1.5; // or undefined
           const desired_retention = 0.9;
           const rating = 3;
-          const result = fsrs.nextInterval(stability, desired_retention, rating);
+          const result = fsrs.nextInterval(stability, desired_retention, rating).toFixed(0);
           console.log("Next interval:", result);
         }
       });

--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
           const stability = 1.5; // or undefined
           const desired_retention = 0.9;
           const rating = 3;
-          const result = fsrs.nextInterval(stability, desired_retention, rating).toFixed(0);
+          const result = fsrs.nextInterval(stability, desired_retention, rating);
           console.log("Next interval:", result);
         }
       });

--- a/sandbox/src/App.tsx
+++ b/sandbox/src/App.tsx
@@ -41,7 +41,7 @@ const App: Component = () => {
 					const desired_retention = 0.9
 					const rating = 3
 					const fsrs = new Fsrs()
-					const result = fsrs.nextInterval(stability, desired_retention, rating)
+					const result = fsrs.nextInterval(stability, desired_retention, rating).toFixed(0)
 					console.log('Next interval:', result)
 					setNextInterval(result.toString())
 					fsrs.free() // for details grep D91EEC72-FCBC-4140-8ADC-9CF2016A56C5

--- a/sandbox/src/App.tsx
+++ b/sandbox/src/App.tsx
@@ -41,7 +41,7 @@ const App: Component = () => {
 					const desired_retention = 0.9
 					const rating = 3
 					const fsrs = new Fsrs()
-					const result = fsrs.nextInterval(stability, desired_retention, rating).toFixed(0)
+					const result = fsrs.nextInterval(stability, desired_retention, rating)
 					console.log('Next interval:', result)
 					setNextInterval(result.toString())
 					fsrs.free() // for details grep D91EEC72-FCBC-4140-8ADC-9CF2016A56C5

--- a/sandbox/tests/prod.spec.ts
+++ b/sandbox/tests/prod.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, Page } from '@playwright/test'
+import { test, expect } from '@playwright/test'
 import { goHome } from './util'
 
 test('check memory state', async ({ page }) => {
@@ -22,13 +22,16 @@ test('check memory state', async ({ page }) => {
 test('check next interval', async ({ page }) => {
 	await goHome(page)
 	await page.getByRole('button', { name: 'Calculate Next Interval' }).click()
-	await expect(page.locator('#nextIntervalResponse')).toHaveText('2')
+	await expect(page.locator('#nextIntervalResponse')).toContainText('.') // ensures that text has updated, so the more specific assertion `.toEqual(2)` can run
+	const nextInterval = await page.locator('#nextIntervalResponse').textContent()
+	const rounded = Math.round(parseFloat(nextInterval))
+	expect(rounded).toEqual(2)
 })
 
 test('check progress and parameters', async ({ page }) => {
 	await goHome(page)
 	await page.getByRole('button', { name: 'Train with example file' }).click()
-	let progress = await page.locator('#progressNumbers').innerText()
+	const progress = await page.locator('#progressNumbers').innerText()
 	expect(progress).toEqual('0/0')
 	await expect
 		.poll(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,7 +131,7 @@ impl FSRSwasm {
         stability: Option<f32>,
         desired_retention: f32,
         rating: u32,
-    ) -> u32 {
+    ) -> f32 {
         self.model
             .next_interval(stability, desired_retention, rating)
     }


### PR DESCRIPTION
## What's Changed between FSRS-rs v1.1.3 and FSRS-rs v1.3.3
* Fix/smooth stability after training by @L-M-Sherlock in https://github.com/open-spaced-repetition/fsrs-rs/pull/212
* Feat/check_and_fill_parameters by @L-M-Sherlock in https://github.com/open-spaced-repetition/fsrs-rs/pull/214
* Check parameters are valid numbers by @dae in https://github.com/open-spaced-repetition/fsrs-rs/pull/217
* Fix/simulator crashes if no history by @L-M-Sherlock in https://github.com/open-spaced-repetition/fsrs-rs/pull/216
* Feat/fine-tune the sample size for CMRR by @L-M-Sherlock in https://github.com/open-spaced-repetition/fsrs-rs/pull/222
* Fix/filter_outlier outputs dataset in arbitrary order by @L-M-Sherlock in https://github.com/open-spaced-repetition/fsrs-rs/pull/223
* Fix/filter rating_stability to match rating_count keys by @L-M-Sherlock in https://github.com/open-spaced-repetition/fsrs-rs/pull/225
* Feat/float next interval by @L-M-Sherlock in https://github.com/open-spaced-repetition/fsrs-rs/pull/213
* R_MIN = 0.70 by @Expertium in https://github.com/open-spaced-repetition/fsrs-rs/pull/229
* Fix/update FSRS-4.5 param into FSRS-5 properly by @L-M-Sherlock in https://github.com/open-spaced-repetition/fsrs-rs/pull/230
* derive Copy for trivial struct by @sineptic in https://github.com/open-spaced-repetition/fsrs-rs/pull/236
* Make simulate iterate by card instead of by day. by @Luc-Mcgrady in https://github.com/open-spaced-repetition/fsrs-rs/pull/235
* Fix/sample_size should be continuous over learn_span by @Expertium in https://github.com/open-spaced-repetition/fsrs-rs/pull/238

**Full Changelog**: https://github.com/open-spaced-repetition/fsrs-rs/compare/v1.1.4...v1.3.3